### PR TITLE
Update BatteryView.swift

### DIFF
--- a/MaskingStuff/BatteryView.swift
+++ b/MaskingStuff/BatteryView.swift
@@ -35,7 +35,7 @@ struct BatteryView: View {
                     .padding()
                 
                 Text("\(Int(self.progress * 100))%")
-                    .foregroundColor(.white)
+                    .foregroundColor(progress <= 0.5 ? .white : .black)
                     .animation(nil)
                     .opacity(opacity)
                 


### PR DESCRIPTION
in the battery view when we scrolled down the battery percentage was less than 50% because the percentage color was black we couldn't see the battery percentage so my added code will show the percentage in white when the battery is less than 50% and in black when the battery percentage is more than 50%. 
Thank Youu.